### PR TITLE
Bug fix mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE>
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset = "utf-8">

--- a/styles.css
+++ b/styles.css
@@ -79,7 +79,7 @@ ul {
     #navbar {
         grid-template-columns: 100%;
         justify-content: center;
-        height: min-content;
+        height: auto;
     }
 
     #main-doc {

--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,7 @@ body {
     color: white;
     text-decoration: none;
     box-sizing: border-box;
+    height: 50px;
 }
 
 .menulink:hover {


### PR DESCRIPTION
Fixed bug for display on mobile. The mobile browsers did not seem to render height: min-content correctly. Changed to height: auto and explicitly stated a height for the menu links. 